### PR TITLE
Prism xamarin working branch

### DIFF
--- a/code/src/Core/Templates/TemplatesRepository.cs
+++ b/code/src/Core/Templates/TemplatesRepository.cs
@@ -122,6 +122,20 @@ namespace Microsoft.Templates.Core
             return GetMetadataInfo("frameworks");
         }
 
+        public IEnumerable<MetadataInfo> GetPlatforms()
+        {
+            var folderName = Path.Combine(Sync?.CurrentContent.Path, Catalog);
+
+            if (!Directory.Exists(folderName))
+            {
+                return Enumerable.Empty<MetadataInfo>();
+            }
+
+            var metadataFile = Path.Combine(folderName, $"platforms.json");
+            var metadata = JsonConvert.DeserializeObject<List<MetadataInfo>>(File.ReadAllText(metadataFile));
+            return metadata;
+        }
+
         public IEnumerable<MetadataInfo> GetFrameworks(string platform)
         {
             return GetFrameworks().Where(m => m.Platforms.Contains(platform));

--- a/code/src/UI/Resources/StringRes.Designer.cs
+++ b/code/src/UI/Resources/StringRes.Designer.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Templates.UI.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New Universal Windows Platform app.
+        ///   Looks up a localized string similar to New {0} app.
         /// </summary>
         public static string NewProjectTitle {
             get {

--- a/code/src/UI/Resources/StringRes.resx
+++ b/code/src/UI/Resources/StringRes.resx
@@ -294,7 +294,7 @@
     <comment>New project: Navigation step two</comment>
   </data>
   <data name="NewProjectTitle" xml:space="preserve">
-    <value>New Universal Windows Platform app</value>
+    <value>New {0} app</value>
     <comment>Wizard title on WizardShell page</comment>
   </data>
   <data name="NotificationRemoveError_Dependency" xml:space="preserve">

--- a/code/src/UI/ViewModels/Common/WizardStatus.cs
+++ b/code/src/UI/ViewModels/Common/WizardStatus.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Templates.UI.ViewModels.Common
     public class WizardStatus : Observable
     {
         private string _title;
+        private string _platformTitle;
         private string _versions;
         private bool _isBusy;
         private bool _isNotBusy;
@@ -36,6 +37,12 @@ namespace Microsoft.Templates.UI.ViewModels.Common
         {
             get => _title;
             set => SetProperty(ref _title, value);
+        }
+
+        public string PlatformTitle
+        {
+            get => _platformTitle;
+            set => SetProperty(ref _platformTitle, value);
         }
 
         public string Versions

--- a/code/src/UI/ViewModels/NewProject/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewProject/MainViewModel.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -65,6 +66,9 @@ namespace Microsoft.Templates.UI.ViewModels.NewProject
         public override async Task InitializeAsync(string platform, string language)
         {
             WizardStatus.Title = $" ({GenContext.Current.ProjectName})";
+            var platforms = GenContext.ToolBox.Repo.GetPlatforms();
+            var platformDisplayName = platforms.FirstOrDefault(x => string.Compare(x.Name, platform, true) == 0)?.DisplayName;
+            WizardStatus.PlatformTitle = string.Format(StringRes.NewProjectTitle, platformDisplayName);
             await base.InitializeAsync(platform, language);
         }
 

--- a/code/src/UI/Views/NewProject/WizardShell.xaml
+++ b/code/src/UI/Views/NewProject/WizardShell.xaml
@@ -62,7 +62,7 @@
                 Orientation="Horizontal"
                 Margin="{StaticResource Margin_L_Left}">
                 <TextBlock
-                    Text="{x:Static strings:StringRes.NewProjectTitle}"
+                    Text="{Binding WizardStatus.PlatformTitle}"
                     Style="{StaticResource WtsTextBlockWizardTitle}" />
                 <TextBlock
                     Text="{Binding WizardStatus.Title}"

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Controls/-.-
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Controls/-.-
@@ -1,1 +1,0 @@
-Placeholder file. Do not delete.

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Helpers/-.-
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Helpers/-.-
@@ -1,1 +1,0 @@
-Placeholder file. Do not delete.

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Models/-.-
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Models/-.-
@@ -1,1 +1,0 @@
-Placeholder file. Do not delete.

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Services/-.-
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Services/-.-
@@ -1,1 +1,0 @@
-Placeholder file. Do not delete.

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Views/-.-
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Views/-.-
@@ -1,1 +1,0 @@
-Placeholder file. Do not delete.

--- a/templates/_catalog/platforms.json
+++ b/templates/_catalog/platforms.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "UWP",
+        "displayName": "Universal Windows Platform"
+    },
+    {
+        "name": "Xamarin",
+        "displayName": "Xamarin Forms"
+    }
+]


### PR DESCRIPTION
Removed placeholder files for .NET Standard templates as they create folders that don't show up in VS and then keep you from adding a folder of the same name. 

Updated the wizard to show the proper project type based on entries in Plaforms.json, though a new platform still requires some extension to the Wizard code to add the new platform to the enumeration values for it. The Platforms.json is used to give a common name such as "Universal Windows Platform" or "Xamarin Forms" for entries such as "UWP" and "Xamarin". 