### PR TITLE
Fix for project missing from solution when named "App"

### DIFF
--- a/code/test/Fakes/Solution/FakeSolution.cs
+++ b/code/test/Fakes/Solution/FakeSolution.cs
@@ -247,8 +247,8 @@ EndProject
         public void AddProjectToSolution(string platform, string projectName, string projectGuid, string projectRelativeToSolutionPath)
         {
             var slnContent = File.ReadAllText(_path);
-
-            if (slnContent.IndexOf(projectName, StringComparison.Ordinal) == -1)
+            var slnFormatProjectName = $"\"{projectName}\",";
+            if (slnContent.IndexOf(slnFormatProjectName, StringComparison.Ordinal) == -1)
             {
                 var globalIndex = slnContent.IndexOf("Global", StringComparison.Ordinal);
                 var projectTemplate = GetProjectTemplate(Path.GetExtension(projectRelativeToSolutionPath));

--- a/code/test/Fakes/Solution/FakeSolution.cs
+++ b/code/test/Fakes/Solution/FakeSolution.cs
@@ -247,8 +247,10 @@ EndProject
         public void AddProjectToSolution(string platform, string projectName, string projectGuid, string projectRelativeToSolutionPath)
         {
             var slnContent = File.ReadAllText(_path);
-            var slnFormatProjectName = $"\"{projectName}\",";
-            if (slnContent.IndexOf(slnFormatProjectName, StringComparison.Ordinal) == -1)
+
+            // Don't match just on projectName as if it's a string also used in the solution such as "App" which is also in "AppStore"
+            // it will cause the project to not be added. Solutions have project name wrapped in " characters and followed by a ,
+            if (slnContent.IndexOf($"\"{projectName}\",", StringComparison.Ordinal) == -1)
             {
                 var globalIndex = slnContent.IndexOf("Global", StringComparison.Ordinal);
                 var projectTemplate = GetProjectTemplate(Path.GetExtension(projectRelativeToSolutionPath));

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Finally found the reason that when you took the default name of "App" in an empty directory the solution didn't include either the shproj or .NET Std project of the Xamarin project if the name of the project was "App" which is the default for any empty directory. When the name was "App" the simple string compare in FakeSolution.cs was matching on the string "AppStore", so I reset the search string to match the format used for a project within a solution, surrounded in " characters, and a comma after it. This stops the false matching.

