### PR TITLE
Fixes for bugs 353 and 354

### DIFF
--- a/code/src/Core/Gen/GenShell.cs
+++ b/code/src/Core/Gen/GenShell.cs
@@ -91,6 +91,14 @@ namespace Microsoft.Templates.Core.Gen
                     var fileContent = File.ReadAllText(appManifestFilePath);
                     result = fileContent.Contains("genTemplate:Metadata");
                 }
+
+                // check for Xamarin projects which will have the UWP project in a subdirectory called ProjectName.UWP
+                appManifestFilePath = Path.Combine(activeProjectPath, $"{GetActiveProjectName()}.UWP", "Package.appxmanifest");
+                if (File.Exists(appManifestFilePath))
+                {
+                    var fileContent = File.ReadAllText(appManifestFilePath);
+                    result = fileContent.Contains("genTemplate:Metadata");
+                }
             }
 
             return result;

--- a/code/src/UI/Generation/ProjectConfigInfo.cs
+++ b/code/src/UI/Generation/ProjectConfigInfo.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Templates.UI.Generation
             {
                 // TODO: Adapt to read project configuration for xamarin forms (X-ref: https://github.com/Microsoft/WindowsTemplateStudio/issues/1350)
                 var path = Path.Combine(GenContext.ToolBox.Shell.GetActiveProjectPath(), "Package.appxmanifest");
+                if (!File.Exists(path))
+                {
+                    path = Path.Combine(Path.Combine(GenContext.ToolBox.Shell.GetActiveProjectPath(), $"{GenContext.ToolBox.Shell.GetActiveProjectName()}.UWP"), "Package.appxmanifest");
+                }
+
                 if (File.Exists(path))
                 {
                     var manifest = XElement.Load(path);

--- a/code/src/UI/ViewModels/NewItem/MainViewModel.cs
+++ b/code/src/UI/ViewModels/NewItem/MainViewModel.cs
@@ -183,6 +183,7 @@ namespace Microsoft.Templates.UI.ViewModels.NewItem
                     ProjectConfigInfo.SaveProjectConfiguration(configInfo.ProjectType, configInfo.Framework, configInfo.Platform);
                     ConfigFramework = configInfo.Framework;
                     ConfigProjectType = configInfo.ProjectType;
+                    ConfigPlatform = configInfo.Platform;
                 }
                 else
                 {

--- a/code/src/UI/Views/NewItem/ProjectConfigurationDialog.xaml
+++ b/code/src/UI/Views/NewItem/ProjectConfigurationDialog.xaml
@@ -40,7 +40,7 @@
                 <TextBlock Text="{Binding DisplayName}" Style="{StaticResource WtsTextBlockProjectConfigurationDescriptionStyle}" />
             </DataTemplate>
             <DataTemplate x:Key="SimpleDisplayNameTemplate">
-                <TextBlock Text="{Binding}" Style="{StaticResource ProjectConfigurationDescriptionStyle}"/>
+                <TextBlock Text="{Binding}" Style="{StaticResource WtsTextBlockProjectConfigurationDescriptionStyle}"/>
             </DataTemplate>
         </ResourceDictionary>
     </Window.Resources>
@@ -65,7 +65,7 @@
                 <TextBlock
                     Text="{x:Static strings:StringRes.ProjectConfigurationSelectPlatform}"
                     Margin="{StaticResource Margin_L_Top}"
-                    Style="{StaticResource ProjectConfigurationComboBoxHeaderStyle}" />
+                    Style="{StaticResource WtsTextBlockProjectConfigurationComboBoxHeaderStyle}" />
                 <ComboBox
                     ItemsSource="{Binding Platforms}"
                     SelectedItem="{Binding SelectedPlatform, Mode=TwoWay}"

--- a/templates/Uwp/Projects/DefaultPrism/Package.appxmanifest
+++ b/templates/Uwp/Projects/DefaultPrism/Package.appxmanifest
@@ -57,5 +57,6 @@
     <genTemplate:Item Name="templatesVersion" Version="Param_Templates.Version" />
     <genTemplate:Item Name="projectType" Value="Param_ProjectType" />
     <genTemplate:Item Name="framework" Value="Param_Framework" />
+    <genTemplate:Item Name="platform" Value="Param_Platform" />
   </genTemplate:Metadata>
 </Package>

--- a/templates/Xamarin/Pages/Blank.Prism/Param_ProjectName/Constants/PageTokens_postaction.cs
+++ b/templates/Xamarin/Pages/Blank.Prism/Param_ProjectName/Constants/PageTokens_postaction.cs
@@ -1,0 +1,10 @@
+﻿namespace Param_RootNamespace
+{
+    internal static class PageTokens
+    {
+        //^^
+        //{[{
+        public const string BlankView = "BlankViewPage";
+        //}]}
+    }
+}

--- a/templates/Xamarin/Pages/Blank.Prism/Param_ProjectName/Views/BlankViewPage.xaml.cs
+++ b/templates/Xamarin/Pages/Blank.Prism/Param_ProjectName/Views/BlankViewPage.xaml.cs
@@ -6,9 +6,9 @@ namespace Param_ItemNamespace.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class BlankViewPage : ContentPage
     {
-        public BlankViewPage ()
+        public BlankViewPage()
         {
-            InitializeComponent ();
+            InitializeComponent();
         }
     }
 }

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/.template.config/template.json
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/.template.config/template.json
@@ -68,6 +68,11 @@
       "type": "parameter",
       "replaces": "Param_Framework"
     },
+    "wts.generationPlatform":
+    {
+      "type": "parameter",
+      "replaces": "Param_Platform"
+    },    
     "copyrightYear": {
         "type": "generated",
         "generator": "now",

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.UWP/MainPage.xaml.cs
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.UWP/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace wts.DefaultProject.UWP
         {
             InitializeComponent();
 
-            LoadApplication(new wts.DefaultProject.App(new UwpInitializer()));
+            LoadApplication(new global::wts.DefaultProject.App(new UwpInitializer()));
         }
     }
 

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.UWP/Package.appxmanifest
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.UWP/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/windowsTemplateStudio"
+  IgnorableNamespaces="uap mp genTemplate">
 
   <Identity 
     Name="add8d809-5ed1-418e-b6e0-f02858f58a31"
@@ -46,4 +47,12 @@
   <Capabilities>
     <Capability Name="internetClient" />
   </Capabilities>
+  <genTemplate:Metadata>
+    <genTemplate:Item Name="generator" Value="Windows Template Studio"/>
+    <genTemplate:Item Name="wizardVersion" Version="Param_Wizard.Version" />
+    <genTemplate:Item Name="templatesVersion" Version="Param_Templates.Version" />
+    <genTemplate:Item Name="projectType" Value="Param_ProjectType" />
+    <genTemplate:Item Name="framework" Value="Param_Framework" />
+    <genTemplate:Item Name="platform" Value="Param_Platform" />
+  </genTemplate:Metadata>
 </Package>

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.iOS/wts.DefaultProject.iOS.csproj
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject.iOS/wts.DefaultProject.iOS.csproj
@@ -132,6 +132,7 @@
       <Project>{c84d6ab8-12fc-46e8-838e-30056ca6c432}</Project>
       <Name>wts.DefaultProject</Name>
     </ProjectReference>
-  </ItemGroup>  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  </ItemGroup>  
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>
 <!--/+:msbuild-conditional:noEmit -->

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Constants/PageTokens.cs
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/Constants/PageTokens.cs
@@ -1,0 +1,6 @@
+﻿namespace wts.DefaultProject
+{
+    internal static class PageTokens
+    {
+    }
+}

--- a/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/wts.DefaultProject.csproj
+++ b/templates/Xamarin/Projects/Default.Prism.NETStd/wts.DefaultProject/wts.DefaultProject.csproj
@@ -7,6 +7,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
     <PackageReference Include="Prism.Unity.Forms" Version="7.0.0.396" />

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/.template.config/template.json
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/.template.config/template.json
@@ -68,6 +68,11 @@
       "type": "parameter",
       "replaces": "Param_Framework"
     },
+    "wts.generationPlatform":
+    {
+      "type": "parameter",
+      "replaces": "Param_Platform"
+    },
     "copyrightYear": {
         "type": "generated",
         "generator": "now",

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/MainPage.xaml.cs
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace wts.DefaultProject.UWP
         {
             InitializeComponent();
 
-            LoadApplication(new wts.DefaultProject.App(new UwpInitializer()));
+            LoadApplication(new global::wts.DefaultProject.App(new UwpInitializer()));
         }
     }
 

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/Package.appxmanifest
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/windowsTemplateStudio"
+  IgnorableNamespaces="uap mp genTemplate">
 
   <Identity 
     Name="add8d809-5ed1-418e-b6e0-f02858f58a31"
@@ -46,4 +47,12 @@
   <Capabilities>
     <Capability Name="internetClient" />
   </Capabilities>
+  <genTemplate:Metadata>
+    <genTemplate:Item Name="generator" Value="Windows Template Studio"/>
+    <genTemplate:Item Name="wizardVersion" Version="Param_Wizard.Version" />
+    <genTemplate:Item Name="templatesVersion" Version="Param_Templates.Version" />
+    <genTemplate:Item Name="projectType" Value="Param_ProjectType" />
+    <genTemplate:Item Name="framework" Value="Param_Framework" />
+    <genTemplate:Item Name="platform" Value="Param_Platform" />
+  </genTemplate:Metadata>
 </Package>

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
@@ -89,7 +89,7 @@
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
-    <ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
     <PackageReference Include="Prism.Unity.Forms" Version="7.0.0.396" />

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject/Constants/PageTokens.cs
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject/Constants/PageTokens.cs
@@ -1,0 +1,6 @@
+﻿namespace wts.DefaultProject
+{
+    internal static class PageTokens
+    {
+    }
+}

--- a/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject/wts.DefaultProject.projitems
+++ b/templates/Xamarin/Projects/Default.Prism.SharedLibrary/wts.DefaultProject/wts.DefaultProject.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Constants\PageTokens.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)App.xaml">
@@ -20,6 +21,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Constants\" />
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <Folder Include="$(MSBuildThisFileDirectory)Helpers\" />
     <Folder Include="$(MSBuildThisFileDirectory)Models\" />

--- a/templates/Xamarin/Projects/Default/.template.config/template.json
+++ b/templates/Xamarin/Projects/Default/.template.config/template.json
@@ -67,6 +67,11 @@
       "type": "parameter",
       "replaces": "Param_Framework"
     },
+    "wts.generationPlatform":
+    {
+      "type": "parameter",
+      "replaces": "Param_Platform"
+    },
     "copyrightYear": {
         "type": "generated",
         "generator": "now",

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.Android/MainActivity.cs
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.Android/MainActivity.cs
@@ -20,7 +20,7 @@ namespace wts.DefaultProject.Droid
             base.OnCreate (bundle);
 
             global::Xamarin.Forms.Forms.Init (this, bundle);
-            LoadApplication (new wts.DefaultProject.App ());
+            LoadApplication (new global::wts.DefaultProject.App ());
         }
     }
 }

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/MainPage.xaml.cs
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/MainPage.xaml.cs
@@ -21,7 +21,7 @@ namespace wts.DefaultProject.UWP
         {
             InitializeComponent();
 
-            LoadApplication(new wts.DefaultProject.App());
+            LoadApplication(new global::wts.DefaultProject.App());
         }
     }
 }

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/Package.appxmanifest
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:genTemplate="http://schemas.microsoft.com/appx/developer/windowsTemplateStudio"
+  IgnorableNamespaces="uap mp genTemplate">
 
   <Identity 
     Name="add8d809-5ed1-418e-b6e0-f02858f58a31"
@@ -46,4 +47,12 @@
   <Capabilities>
     <Capability Name="internetClient" />
   </Capabilities>
+  <genTemplate:Metadata>
+    <genTemplate:Item Name="generator" Value="Windows Template Studio"/>
+    <genTemplate:Item Name="wizardVersion" Version="Param_Wizard.Version" />
+    <genTemplate:Item Name="templatesVersion" Version="Param_Templates.Version" />
+    <genTemplate:Item Name="projectType" Value="Param_ProjectType" />
+    <genTemplate:Item Name="framework" Value="Param_Framework" />
+    <genTemplate:Item Name="platform" Value="Param_Platform" />
+  </genTemplate:Metadata>
 </Package>

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.UWP/wts.DefaultProject.UWP.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.15063.0</TargetPlatformMinVersion>
+    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -89,13 +89,9 @@
     <Prefer32Bit>true</Prefer32Bit>
     <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
   </PropertyGroup>
-    <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.2.2</Version>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>2.4.0.280</Version>
-    </PackageReference>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.iOS/AppDelegate.cs
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.iOS/AppDelegate.cs
@@ -23,7 +23,7 @@ namespace wts.DefaultProject.iOS
         public override bool FinishedLaunching(UIApplication app, NSDictionary options)
         {
             global::Xamarin.Forms.Forms.Init ();
-            LoadApplication (new wts.DefaultProject.App ());
+            LoadApplication (new global::wts.DefaultProject.App ());
 
             return base.FinishedLaunching (app, options);
         }

--- a/templates/Xamarin/Projects/Default/wts.DefaultProject.iOS/wts.DefaultProject.iOS.csproj
+++ b/templates/Xamarin/Projects/Default/wts.DefaultProject.iOS/wts.DefaultProject.iOS.csproj
@@ -121,29 +121,13 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <Reference Include="Xamarin.Forms.Core, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Platform, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Platform.iOS, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xamarin.Forms.2.4.0.280\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.iOS" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.0.0.446417" />
+    <PackageReference Include="Prism.Unity.Forms" Version="7.0.0.396" />
   </ItemGroup>
   <Import Project="..\wts.DefaultProject\wts.DefaultProject.projitems" Label="Shared" Condition="Exists('..\wts.DefaultProject\wts.DefaultProject.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.props'))" />
-    <Error Condition="!Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets'))" />
-  </Target>
-  <Import Project="..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.4.0.280\build\netstandard1.0\Xamarin.Forms.targets')" />
 </Project>
 <!--/+:msbuild-conditional:noEmit -->

--- a/templates/Xamarin/_composition/Prism/Page.MasterDetail.RegisterPage/Param_ProjectName/ViewModels/RootMasterDetailPageViewModel_postaction.cs
+++ b/templates/Xamarin/_composition/Prism/Page.MasterDetail.RegisterPage/Param_ProjectName/ViewModels/RootMasterDetailPageViewModel_postaction.cs
@@ -6,7 +6,7 @@
         {
             //^^
             //{[{
-            new MasterDetailPageMenuItem { Title = "wts.ItemName", TargetPage = "wts.ItemNamePage", IconSource = "blank.png"},
+            new MasterDetailPageMenuItem { Title = "wts.ItemName", TargetPage = PageTokens.wts.ItemName, IconSource = "blank.png"},
             //}]}
         };
     }

--- a/templates/Xamarin/_composition/Prism/Page.Navigation.RegisterPage/Param_ProjectName/App_postaction.xaml.cs
+++ b/templates/Xamarin/_composition/Prism/Page.Navigation.RegisterPage/Param_ProjectName/App_postaction.xaml.cs
@@ -11,7 +11,7 @@ namespace Param_RootNamespace
             containerRegistry.RegisterForNavigation<NavigationPage>();
             //^^
             //{[{
-            containerRegistry.RegisterForNavigation<wts.ItemNamePage>();
+            containerRegistry.RegisterForNavigation<wts.ItemNamePage, wts.ItemNameViewModel >();
             //}]}
         }
     }

--- a/templates/Xamarin/_composition/Prism/Page.Navigation.RegisterPage/Param_ProjectName/App_postaction.xaml.cs
+++ b/templates/Xamarin/_composition/Prism/Page.Navigation.RegisterPage/Param_ProjectName/App_postaction.xaml.cs
@@ -11,7 +11,7 @@ namespace Param_RootNamespace
             containerRegistry.RegisterForNavigation<NavigationPage>();
             //^^
             //{[{
-            containerRegistry.RegisterForNavigation<wts.ItemNamePage, wts.ItemNameViewModel >();
+            containerRegistry.RegisterForNavigation<wts.ItemNamePage, wts.ItemNameViewModel>();
             //}]}
         }
     }

--- a/templates/Xamarin/_composition/Prism/Project.MasterDetail/Param_ProjectName/ViewModels/RootMasterDetailPageViewModel.cs
+++ b/templates/Xamarin/_composition/Prism/Project.MasterDetail/Param_ProjectName/ViewModels/RootMasterDetailPageViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using Param_RootNamespace.Models;
 using Param_RootNamespace.Views;
+using Param_RootNamespace;
 using Prism.Navigation;
 using Prism.Commands;
 


### PR DESCRIPTION
Fixes for bugs 353 and 354 with wire up of ViewModel/View wire up for Prism by registering the ViewModels with the Views. With wiring up explicitly there is no need for the AutoWireup attribute in the pages.